### PR TITLE
testing

### DIFF
--- a/rollup_client/Cargo.toml
+++ b/rollup_client/Cargo.toml
@@ -14,3 +14,8 @@ anyhow = "1.0"
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
 bincode = "1.3.3"
+rollup_core = { path = "../rollup_core" }
+
+[dev-dependencies]
+tokio-test = "0.4"
+tempfile = "3.8"

--- a/rollup_client/src/lib.rs
+++ b/rollup_client/src/lib.rs
@@ -1,0 +1,113 @@
+use anyhow::Result;
+use reqwest::Client;
+use rollup_core::RollupTransaction;
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::{
+    hash::Hash,
+    native_token::LAMPORTS_PER_SOL,
+    signature::{Keypair, Signer},
+    system_instruction,
+    transaction::Transaction,
+};
+use std::collections::HashMap;
+
+/// Create a Solana transaction for testing/demonstration
+pub fn create_solana_transaction(
+    from: &Keypair,
+    to: &Keypair,
+    amount: u64,
+    recent_blockhash: Hash,
+) -> Transaction {
+    let ix = system_instruction::transfer(&from.pubkey(), &to.pubkey(), amount);
+    Transaction::new_signed_with_payer(&[ix], Some(&from.pubkey()), &[from], recent_blockhash)
+}
+
+/// Submit a transaction to the rollup server
+pub async fn submit_transaction_to_rollup(
+    client: &Client,
+    base_url: &str,
+    sender_name: &str,
+    transaction: Transaction,
+) -> Result<HashMap<String, String>> {
+    let rollup_tx = RollupTransaction {
+        sender: sender_name.to_string(),
+        sol_transaction: transaction,
+    };
+
+    let response = client
+        .post(&format!("{}/submit_transaction", base_url))
+        .json(&rollup_tx)
+        .send()
+        .await?
+        .json::<HashMap<String, String>>()
+        .await?;
+
+    Ok(response)
+}
+
+/// Calculate the keccak hash of a transaction signature for lookup
+pub fn calculate_signature_hash(signature: &str) -> String {
+    solana_sdk::keccak::hashv(&[signature.as_bytes()]).to_string()
+}
+
+/// Get a transaction from the rollup server using its signature hash
+pub async fn get_transaction_from_rollup(
+    client: &Client,
+    base_url: &str,
+    signature_hash: &str,
+) -> Result<RollupTransaction> {
+    let get_request = HashMap::from([("get_tx", signature_hash.to_string())]);
+
+    let response = client
+        .post(&format!("{}/get_transaction", base_url))
+        .json(&get_request)
+        .send()
+        .await?
+        .json::<RollupTransaction>()
+        .await?;
+
+    Ok(response)
+}
+
+/// Perform a health check on the rollup server
+pub async fn health_check(client: &Client, base_url: &str) -> Result<HashMap<String, String>> {
+    let response = client
+        .get(&format!("{}/", base_url))
+        .send()
+        .await?
+        .json::<HashMap<String, String>>()
+        .await?;
+
+    Ok(response)
+}
+
+/// Create a complete rollup client for interacting with the server
+pub struct RollupClient {
+    client: Client,
+    base_url: String,
+}
+
+impl RollupClient {
+    pub fn new(base_url: String) -> Self {
+        Self {
+            client: Client::new(),
+            base_url,
+        }
+    }
+
+    pub async fn health_check(&self) -> Result<HashMap<String, String>> {
+        health_check(&self.client, &self.base_url).await
+    }
+
+    pub async fn submit_transaction(
+        &self,
+        sender_name: &str,
+        transaction: Transaction,
+    ) -> Result<HashMap<String, String>> {
+        submit_transaction_to_rollup(&self.client, &self.base_url, sender_name, transaction).await
+    }
+
+    pub async fn get_transaction(&self, signature_hash: &str) -> Result<RollupTransaction> {
+        get_transaction_from_rollup(&self.client, &self.base_url, signature_hash).await
+    }
+}

--- a/rollup_client/tests/integration_test.rs
+++ b/rollup_client/tests/integration_test.rs
@@ -1,0 +1,298 @@
+use anyhow::Result;
+use rollup_client::{calculate_signature_hash, create_solana_transaction, RollupClient};
+use solana_sdk::{
+    hash::Hash,
+    native_token::LAMPORTS_PER_SOL,
+    signature::{Keypair, Signer},
+};
+use std::{
+    process::{Child, Command},
+    time::Duration,
+};
+use tokio::time::sleep;
+
+/// Test server manager to handle rollup_core server lifecycle
+struct TestServer {
+    child: Option<Child>,
+    rollup_client: RollupClient,
+}
+
+impl TestServer {
+    /// Start the rollup_core server in the background
+    async fn start() -> Result<Self> {
+        println!("Starting rollup_core server...");
+
+        // Start the rollup_core server as a background process
+        let child = Command::new("cargo")
+            .args(&["run"])
+            .current_dir("../rollup_core")
+            .spawn()
+            .expect("Failed to start rollup_core server");
+
+        let rollup_client = RollupClient::new("http://127.0.0.1:8080".to_string());
+        let server = TestServer {
+            child: Some(child),
+            rollup_client,
+        };
+
+        // Wait for server to be ready
+        server.wait_for_ready().await?;
+
+        Ok(server)
+    }
+
+    /// Wait for the server to be ready by polling the test endpoint
+    async fn wait_for_ready(&self) -> Result<()> {
+        let max_attempts = 30; // 30 seconds timeout
+
+        for _ in 0..max_attempts {
+            match self.rollup_client.health_check().await {
+                Ok(_) => {
+                    println!("Server is ready!");
+                    return Ok(());
+                }
+                Err(_) => {
+                    println!("Waiting for server to start...");
+                    sleep(Duration::from_secs(1)).await;
+                }
+            }
+        }
+
+        anyhow::bail!("Server failed to start within timeout period");
+    }
+
+    /// Get reference to the rollup client
+    fn client(&self) -> &RollupClient {
+        &self.rollup_client
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            println!("Stopping rollup_core server...");
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+/// Create a test keypair for testing
+fn create_test_keypair() -> Keypair {
+    Keypair::new()
+}
+
+#[tokio::test]
+async fn test_complete_rollup_flow() -> Result<()> {
+    println!("=== Starting Complete Rollup Flow Integration Test ===");
+
+    // Start the rollup server
+    let server = TestServer::start().await?;
+    let client = server.client();
+
+    //  Test the server is running with basic health check
+    println!("\n1. Testing server health check...");
+    let health_response = client.health_check().await?;
+    println!("Health check response: {:#?}", health_response);
+    assert_eq!(health_response.get("test"), Some(&"success".to_string()));
+
+    // Create test transaction
+    println!("\n2. Creating test transaction...");
+    let sender_keypair = create_test_keypair();
+    let receiver_keypair = create_test_keypair();
+    let amount = 1 * LAMPORTS_PER_SOL;
+
+    // Use a mock recent blockhash for testing
+    let recent_blockhash = Hash::default();
+    let sol_transaction =
+        create_solana_transaction(&sender_keypair, &receiver_keypair, amount, recent_blockhash);
+    let original_signature = sol_transaction.signatures[0];
+
+    println!("Created transaction with signature: {}", original_signature);
+    println!("From: {}", sender_keypair.pubkey());
+    println!("To: {}", receiver_keypair.pubkey());
+    println!("Amount: {} lamports", amount);
+
+    // Submit transaction to rollup using client library
+    println!("\n3. Submitting transaction to rollup...");
+    let submit_response = client
+        .submit_transaction("Integration Test", sol_transaction.clone())
+        .await?;
+    println!("Submit response: {:#?}", submit_response);
+    assert_eq!(
+        submit_response.get("Transaction status"),
+        Some(&"Submitted".to_string())
+    );
+
+    // Calculate transaction hash for retrieval using library function
+    println!("\n4. Calculating transaction hash...");
+    let tx_sig = original_signature.to_string();
+    let sig_hash_string = calculate_signature_hash(&tx_sig);
+
+    println!("Original signature: {}", tx_sig);
+    println!("Hash for lookup: {}", sig_hash_string);
+
+    // Wait a bit for transaction processing
+    println!("\n5. Waiting for transaction processing...");
+    sleep(Duration::from_millis(100)).await;
+
+    // Retrieve transaction from rollup using client library
+    println!("\n6. Retrieving transaction from rollup...");
+    let retrieved_tx = client.get_transaction(&sig_hash_string).await?;
+    println!("Retrieved transaction: {:#?}", retrieved_tx);
+
+    // Verify the retrieved transaction matches the original
+    println!("\n7. Verifying transaction integrity...");
+
+    // Check that the sender is from rollup
+    assert_eq!(retrieved_tx.sender, "Rollup RPC");
+
+    // Check that the transaction signature matches
+    let retrieved_signature = retrieved_tx.sol_transaction.signatures[0];
+    assert_eq!(retrieved_signature, original_signature);
+    println!("✓ Signatures match: {}", retrieved_signature);
+
+    // Check that the transaction instructions match
+    assert_eq!(
+        retrieved_tx.sol_transaction.message.instructions.len(),
+        sol_transaction.message.instructions.len()
+    );
+    println!(
+        "✓ Instruction count matches: {}",
+        retrieved_tx.sol_transaction.message.instructions.len()
+    );
+
+    // Verify the account keys match
+    assert_eq!(
+        retrieved_tx.sol_transaction.message.account_keys,
+        sol_transaction.message.account_keys
+    );
+    println!("✓ Account keys match");
+
+    // Verify the recent blockhash matches
+    assert_eq!(
+        retrieved_tx.sol_transaction.message.recent_blockhash,
+        sol_transaction.message.recent_blockhash
+    );
+    println!("✓ Recent blockhash matches");
+
+    println!("\n=== Integration Test Completed Successfully! ===");
+    println!(" All assertions passed");
+    println!(" Complete rollup flow verified");
+    println!(" Used actual functions from rollup_client and rollup_core libraries");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_svm_execution_flow() -> Result<()> {
+    println!("=== Testing SVM Execution Flow ===");
+
+    let server = TestServer::start().await?;
+    let client = server.client();
+
+    // Create a simple transfer transaction
+    println!("\n1. Creating transfer transaction for SVM execution...");
+    let sender = create_test_keypair();
+    let receiver = create_test_keypair();
+    let amount = 5000; // 5000 lamports
+
+    let transaction = create_solana_transaction(&sender, &receiver, amount, Hash::default());
+    println!("Transaction created:");
+    println!("  From: {}", sender.pubkey());
+    println!("  To: {}", receiver.pubkey());
+    println!("  Amount: {} lamports", amount);
+    println!("  Signature: {}", transaction.signatures[0]);
+
+    // Submit transaction - this will trigger SVM execution
+    println!("\n2. Submitting transaction (will trigger SVM execution)...");
+    let submit_response = client
+        .submit_transaction("SVM Test", transaction.clone())
+        .await?;
+    println!("Submit response: {:#?}", submit_response);
+
+    // Wait for SVM processing to complete
+    println!("\n3. Waiting for SVM processing...");
+    sleep(Duration::from_millis(500)).await; // Give more time for SVM processing
+
+    // Retrieve the transaction to confirm it was processed
+    println!("\n4. Retrieving processed transaction...");
+    let sig_hash = calculate_signature_hash(&transaction.signatures[0].to_string());
+    let retrieved_tx = client.get_transaction(&sig_hash).await?;
+
+    // Verify transaction was stored after SVM processing
+    println!("\n5. Verifying SVM processing completed...");
+    assert_eq!(retrieved_tx.sender, "Rollup RPC");
+    assert_eq!(
+        retrieved_tx.sol_transaction.signatures[0],
+        transaction.signatures[0]
+    );
+
+    println!(" SVM Execution Flow Test Completed!");
+    println!(" Transaction submitted, processed by SVM, and stored successfully");
+    println!(" Retrieved transaction matches original");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rollup_error_handling() -> Result<()> {
+    println!("=== Testing Rollup Error Handling ===");
+
+    let server = TestServer::start().await?;
+    let client = server.client();
+
+    // Test 1: Try to get a non-existent transaction
+    println!("\n1. Testing retrieval of non-existent transaction...");
+    let fake_hash = "invalid_hash_that_does_not_exist";
+
+    match client.get_transaction(fake_hash).await {
+        Ok(response) => {
+            // If it doesn't error, check if it's a fallback response
+            println!("Fallback response received: {:#?}", response);
+        }
+        Err(e) => {
+            println!(" Server correctly rejected invalid hash: {}", e);
+        }
+    }
+
+    println!("\n=== Error Handling Test Completed ===");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_rollup_client_functionality() -> Result<()> {
+    println!("=== Testing RollupClient Functionality ===");
+
+    let server = TestServer::start().await?;
+    let client = server.client();
+
+    // Test the rollup client's individual methods
+    println!("\n1. Testing health check method...");
+    let health = client.health_check().await?;
+    assert!(health.contains_key("test"));
+    println!("✓ Health check method works");
+
+    // Test transaction creation utility
+    println!("\n2. Testing transaction creation utility...");
+    let keypair1 = create_test_keypair();
+    let keypair2 = create_test_keypair();
+    let tx = create_solana_transaction(&keypair1, &keypair2, 1000, Hash::default());
+    assert_eq!(tx.signatures.len(), 1);
+    assert_eq!(tx.message.instructions.len(), 1);
+    println!("✓ Transaction creation utility works");
+
+    // Test signature hash calculation
+    println!("\n3. Testing signature hash calculation...");
+    let sig_str = tx.signatures[0].to_string();
+    let hash1 = calculate_signature_hash(&sig_str);
+    let hash2 = calculate_signature_hash(&sig_str);
+    assert_eq!(hash1, hash2); // Should be deterministic
+    assert!(!hash1.is_empty());
+    println!("✓ Signature hash calculation works: {}", hash1);
+
+    println!("\n=== RollupClient Functionality Test Completed ===");
+
+    Ok(())
+}


### PR DESCRIPTION
### How to run

```bash
# From workspace root or inside rollup_client
cargo test -p rollup_client --test integration_test

# Run a single test (examples)
cargo test -p rollup_client test_complete_rollup_flow -- --nocapture
cargo test -p rollup_client test_svm_execution_flow -- --nocapture
```

- Tests auto-start `rollup_core` on `http://127.0.0.1:8080` and shut it down afterwards.

- Removed some redundent imports . 
- Added lib.rs in rollupclient and shifted the code from main.rs to it .

### What it does (quick points)

- Starts the rollup server and waits for `health_check` to pass.
- Builds a simple Solana transfer and submits it via `RollupClient`.
- Waits briefly, then retrieves the transaction by a hash of its signature.
- Verifies key fields match (signature, instructions, account keys, blockhash).
- Checks SVM processing after submission and basic error handling for invalid hashes.
