### PR TITLE
Done with transaction batching and caching of accounts

### DIFF
--- a/rollup_client/Cargo.toml
+++ b/rollup_client/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0"
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
 bincode = "1.3.3"
-rollup_core = { path = "/home/jvan/zksvm/rollup_core" }
+rollup_core = { path = "../rollup_core" }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/rollup_client/Cargo.toml
+++ b/rollup_client/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0"
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
 bincode = "1.3.3"
-rollup_core = { path = "../rollup_core" }
+rollup_core = { path = "/home/jvan/zksvm/rollup_core" }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/rollup_client/src/lib.rs
+++ b/rollup_client/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use reqwest::Client;
-use rollup_core::RollupTransaction;
+
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{
     hash::Hash,
@@ -10,6 +10,7 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use std::collections::HashMap;
+use rollup_core::frontend::RollupTransaction;
 
 /// Create a Solana transaction for testing/demonstration
 pub fn create_solana_transaction(

--- a/rollup_client/src/main.rs
+++ b/rollup_client/src/main.rs
@@ -5,8 +5,8 @@ use solana_sdk::{native_token::LAMPORTS_PER_SOL, signer};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let keypair = signer::keypair::read_keypair_file("/home/dev/.solana/testkey.json").unwrap();
-    let keypair2 = signer::keypair::read_keypair_file("/home/dev/.solana/mykey_1.json").unwrap();
+    let keypair = signer::keypair::read_keypair_file("/home/jvan/.solana/testkey.json").unwrap();
+    let keypair2 = signer::keypair::read_keypair_file("/home/jvan/.solana/mykey_1.json").unwrap();
     let rpc_client = RpcClient::new("https://api.devnet.solana.com".into());
 
     // Get recent blockhash from Solana
@@ -31,10 +31,13 @@ async fn main() -> Result<()> {
     let sig_hash_b58 = calculate_signature_hash(&tx_sig);
     println!("Sig: {}", tx_sig);
     println!("Sig_hash: {:#?}", sig_hash_b58);
-
-    println!("Getting transaction...");
-    let tx_resp = rollup_client.get_transaction(&sig_hash_b58).await?;
-    println!("{tx_resp:#?}");
+    
+    
+    //comment this while running the client multiple times 
+    
+    // println!("Getting transaction...");
+    // let tx_resp = rollup_client.get_transaction(&sig_hash_b58).await?;
+    // println!("{tx_resp:#?}");
 
     Ok(())
 }

--- a/rollup_client/src/main.rs
+++ b/rollup_client/src/main.rs
@@ -5,8 +5,8 @@ use solana_sdk::{native_token::LAMPORTS_PER_SOL, signer};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let keypair = signer::keypair::read_keypair_file("/home/jvan/.solana/testkey.json").unwrap();
-    let keypair2 = signer::keypair::read_keypair_file("/home/jvan/.solana/mykey_1.json").unwrap();
+    let keypair = signer::keypair::read_keypair_file("/home/dev/.solana/testkey.json").unwrap();
+    let keypair2 = signer::keypair::read_keypair_file("/home/dev/.solana/mykey_1.json").unwrap();
     let rpc_client = RpcClient::new("https://api.devnet.solana.com".into());
 
     // Get recent blockhash from Solana
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
     
     
     //comment this while running the client multiple times 
-    
+
     // println!("Getting transaction...");
     // let tx_resp = rollup_client.get_transaction(&sig_hash_b58).await?;
     // println!("{tx_resp:#?}");

--- a/rollup_client/tests/integration_test.rs
+++ b/rollup_client/tests/integration_test.rs
@@ -3,7 +3,7 @@ use rollup_client::{calculate_signature_hash, create_solana_transaction, RollupC
 use solana_sdk::{
     hash::Hash,
     native_token::LAMPORTS_PER_SOL,
-    signature::{Keypair, Signer},
+    signature::{Keypair, Signer}, signer,
 };
 use std::{
     process::{Child, Command},
@@ -98,8 +98,11 @@ async fn test_complete_rollup_flow() -> Result<()> {
 
     // Create test transaction
     println!("\n2. Creating test transaction...");
-    let sender_keypair = create_test_keypair();
-    let receiver_keypair = create_test_keypair();
+    // let sender_keypair = create_test_keypair();
+    // let receiver_keypair = create_test_keypair();
+    let sender_keypair = signer::keypair::read_keypair_file("/home/jvan/.solana/testkey.json").unwrap();
+    let receiver_keypair = signer::keypair::read_keypair_file("/home/jvan/.solana/mykey_1.json").unwrap();
+    
     let amount = 1 * LAMPORTS_PER_SOL;
 
     // Use a mock recent blockhash for testing
@@ -193,8 +196,11 @@ async fn test_svm_execution_flow() -> Result<()> {
 
     // Create a simple transfer transaction
     println!("\n1. Creating transfer transaction for SVM execution...");
-    let sender = create_test_keypair();
-    let receiver = create_test_keypair();
+    // let sender = create_test_keypair();
+    // let receiver = create_test_keypair();
+    let sender = signer::keypair::read_keypair_file("/home/jvan/.solana/testkey.json").unwrap();
+    let receiver = signer::keypair::read_keypair_file("/home/jvan/.solana/mykey_1.json").unwrap();
+    
     let amount = 5000; // 5000 lamports
 
     let transaction = create_solana_transaction(&sender, &receiver, amount, Hash::default());
@@ -276,8 +282,11 @@ async fn test_rollup_client_functionality() -> Result<()> {
 
     // Test transaction creation utility
     println!("\n2. Testing transaction creation utility...");
-    let keypair1 = create_test_keypair();
-    let keypair2 = create_test_keypair();
+    // let keypair1 = create_test_keypair();
+    // let keypair2 = create_test_keypair();
+    let keypair1 = signer::keypair::read_keypair_file("/home/jvan/.solana/testkey.json").unwrap();
+    let keypair2 = signer::keypair::read_keypair_file("/home/jvan/.solana/mykey_1.json").unwrap();
+    
     let tx = create_solana_transaction(&keypair1, &keypair2, 1000, Hash::default());
     assert_eq!(tx.signatures.len(), 1);
     assert_eq!(tx.message.instructions.len(), 1);

--- a/rollup_core/src/frontend.rs
+++ b/rollup_core/src/frontend.rs
@@ -29,8 +29,8 @@ pub struct GetTransaction {
 // message format used to receive transactions from clients
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RollupTransaction {
-    sender: String,
-    sol_transaction: Transaction,
+    pub sender: String,
+    pub sol_transaction: Transaction,
 }
 
 pub async fn submit_transaction(
@@ -70,6 +70,7 @@ pub async fn get_transaction(
                 Hash::from_str(&body.get_tx).map_err(|_| error::ErrorBadRequest("Invalid hash"))?,
             ),
             add_settle_proof: None,
+            add_new_data:None
         })
         .unwrap();
     log::info!("Sending to rollupdb worked getrequest");

--- a/rollup_core/src/lib.rs
+++ b/rollup_core/src/lib.rs
@@ -1,0 +1,3 @@
+//added this file for accessing contents in following files for testing
+pub mod frontend;
+mod rollupdb;

--- a/rollup_core/src/loader.rs
+++ b/rollup_core/src/loader.rs
@@ -1,0 +1,85 @@
+use {
+    solana_client::rpc_client::RpcClient,
+    solana_sdk::{
+        account::{Account, AccountSharedData, ReadableAccount},
+        pubkey::Pubkey,
+    },
+    solana_svm::transaction_processing_callback::TransactionProcessingCallback,
+    std::{collections::HashMap, sync::RwLock},
+    solana_svm_callback::InvokeContextCallback,
+    solana_sdk::precompiles::PrecompileError
+};
+
+impl InvokeContextCallback for RollupAccountLoader<'_> {
+    fn get_epoch_stake(&self) -> u64 {
+        0 // Stub implementation
+    }
+
+    fn get_epoch_stake_for_vote_account(&self, _vote_address: &Pubkey) -> u64 {
+        0 // Stub implementation
+    }
+
+    fn is_precompile(&self, _program_id: &Pubkey) -> bool {
+        false // Stub implementation
+    }
+
+    fn process_precompile(
+        &self,
+        _program_id: &Pubkey,
+        _data: &[u8],
+        _instruction_datas: Vec<&[u8]>,
+    ) -> Result<(), PrecompileError> {
+        Err(PrecompileError::InvalidPublicKey) // Stub implementation
+    }
+}
+
+pub struct RollupAccountLoader<'a>{
+    pub cache: RwLock<HashMap<Pubkey,AccountSharedData>>,
+    pub rpc_client: &'a RpcClient,
+}
+
+impl<'a> RollupAccountLoader<'a>  {
+    pub fn new(rpc_client: &'a RpcClient)->Self{
+        Self { cache: RwLock::new(HashMap::new()), rpc_client }
+    }
+
+    pub fn add_account(&mut self,pubkey:Pubkey,modified_new_accounts:AccountSharedData){
+        let mut map = self.cache.write().unwrap();
+        map.insert(pubkey, modified_new_accounts);
+        log::info!("updated account in cache: {:?}", map);
+    }
+}
+
+/// Implementation of the SVM API's `TransactionProcessingCallback` interface.
+impl TransactionProcessingCallback for RollupAccountLoader<'_>{
+    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
+        //check the local cache first
+        if let Some(account) = self.cache.read().unwrap().get(pubkey){
+            log::info!("Account {} loaded from cache", pubkey);
+            return Some(account.clone());
+        }
+
+        //not in cache, fetch from the base chain (solana)
+        match self.rpc_client.get_account(pubkey){
+            Ok(account)=>{
+                let account_data: AccountSharedData = account.into();
+
+                //storing the fetched account in the cache for next time.
+                self.cache.write().unwrap().insert(*pubkey, account_data.clone());
+                Some(account_data)
+            }
+            Err(_) => None,
+        }
+    }
+    fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize> {
+        self.get_account_shared_data(account).and_then(|account| owners.iter().position(|key| account.owner().eq(key)))
+    }
+
+    fn add_builtin_account(&self, _name: &str, _program_id: &Pubkey) {
+        // Not needed for your rollup, can be empty
+    }
+
+    fn get_current_epoch_vote_account_stake(&self, _vote_address: &Pubkey) -> u64 {
+        0 // Stub implementation
+    }
+}

--- a/rollup_core/src/sequencer.rs
+++ b/rollup_core/src/sequencer.rs
@@ -10,6 +10,7 @@ use solana_client::{nonblocking::rpc_client as nonblocking_rpc_client, rpc_clien
 use solana_compute_budget::compute_budget::{
     ComputeBudget, SVMTransactionExecutionBudget, SVMTransactionExecutionCost,
 };
+use async_channel::Receiver;
 use solana_program_runtime::{
     invoke_context::{self, EnvironmentConfig, InvokeContext},
     loaded_programs::{
@@ -34,10 +35,9 @@ use solana_sdk::{
     transaction_context::TransactionContext,
 };
 use solana_svm::{
-    transaction_processing_callback::TransactionProcessingCallback,
-    transaction_processor::{
+    transaction_processing_callback::TransactionProcessingCallback, transaction_processing_result::ProcessedTransaction, transaction_processor::{
         TransactionBatchProcessor, TransactionProcessingConfig, TransactionProcessingEnvironment,
-    },
+    }
 };
 
 use crate::{
@@ -46,210 +46,207 @@ use crate::{
     },
     rollupdb::RollupDBMessage,
     settle::settle_state,
+    loader::RollupAccountLoader
 };
 
-pub fn run(
+
+
+fn process_transaction_batch(
+    transaction_batch : &[Transaction],
+    rollup_account_loader :&RollupAccountLoader,
+    rollupdb_sender: &CBSender<RollupDBMessage>
+)->Result<()>{
+    let compute_budget = SVMTransactionExecutionBudget::default();
+    let feature_set = SVMFeatureSet::all_enabled();
+    let fee_structure = FeeStructure::default();
+    let rent_collector = RentCollector::default();
+    let fork_graph = Arc::new(RwLock::new(RollupForkGraph {}));
+
+    let processor = create_transaction_batch_processor(
+        rollup_account_loader,
+        &feature_set,
+        &compute_budget,
+        Arc::clone(&fork_graph),
+    );
+    
+    let processing_environment = TransactionProcessingEnvironment {
+        blockhash: Hash::default(),
+        blockhash_lamports_per_signature: fee_structure.lamports_per_signature,
+        epoch_total_stake: 0,
+        feature_set,
+        rent_collector: Some(&rent_collector),
+    };
+
+    let processing_config = TransactionProcessingConfig::default();
+
+    let sanitized_txs: Vec<SanitizedTransaction> = transaction_batch
+        .iter()
+        .map(|tx| SanitizedTransaction::try_from_legacy_transaction(tx.clone(), &HashSet::new()).unwrap())
+        .collect();
+
+    println!("Loading and executing a batch of sanitized transactions...");
+    let results = processor.load_and_execute_sanitized_transactions(
+        rollup_account_loader,
+        &sanitized_txs,
+        get_transaction_check_results(sanitized_txs.len()),
+        &processing_environment,
+        &processing_config,
+    );
+    for (i, res) in results.processing_results.iter().enumerate() {
+        let original_tx = &transaction_batch[i];
+
+        match res {
+            Ok(ProcessedTransaction::Executed(tx_details)) => {
+                // This transaction was successful!
+                let new_data = tx_details.loaded_transaction.accounts.clone();
+                log::info!(
+                    "✅ Transaction successful. Sending updated state to DB for tx: {:?}",
+                    original_tx.signatures[0]
+                );
+
+                // Send the successful transaction and its new data to the database
+                rollupdb_sender.send(RollupDBMessage {
+                    lock_accounts: None,
+                    add_processed_transaction: Some(original_tx.clone()),
+                    add_new_data: Some(new_data),
+                    frontend_get_tx: None,
+                    add_settle_proof: None,
+                })?;
+            }
+             Err(e) => {
+                log::error!(
+                    "❌ Transaction failed to execute for tx: {:?}, Error: {}",
+                    original_tx.signatures[0],
+                    e
+                );
+                // We do not send failed transactions to the DB to maintain state integrity.
+            }
+            _ => { // Catches other cases like FeesOnly
+                 log::warn!(
+                    "⚠️ Transaction produced no state change for tx: {:?}",
+                    original_tx.signatures[0]
+                );
+            }
+        }
+    }
+    // //extracting new account data from the results
+    // let new_data: Vec<Option<Vec<(Pubkey,AccountSharedData)>>> = results.
+    // processing_results
+    // .iter()
+    // .map(|res | {
+    //     res.as_ref().ok().and_then(|processed_tx|{
+    //         if let ProcessedTransaction::Executed(tx) = processed_tx{
+    //             Some(tx.loaded_transaction.accounts.clone())
+    //         }else {
+    //             None
+    //         }
+    //     })
+    // })
+    // .collect();
+
+    // //for testing
+    // let first_index_data = new_data[0].as_ref().;
+    // log::info!("Sequencer processed transaction, new data: {:?}", first_index_data);
+
+
+
+    // // Lock accounts for the entire batch
+    // // let accounts_to_lock: Vec<Pubkey> = transaction_batch
+    // //     .iter()
+    // //     .flat_map(|tx| tx.message.account_keys.clone())
+    // //     .collect();
+
+    // // Send the entire batch of processed transactions to RollupDB
+    // for tx in transaction_batch {
+    //     rollupdb_sender
+    //         .send(RollupDBMessage {
+    //             lock_accounts: None, //Locking will be handled diffrently by the DB
+    //             frontend_get_tx: None,
+    //             add_settle_proof: None,
+    //             add_processed_transaction: Some(tx.clone()),
+    //             add_new_data: Some(first_index_data.clone())
+    //         })
+    //         .map_err(|_| anyhow!("failed to send message to rollupdb"))?;
+    // }
+
+    Ok(())
+}
+
+
+pub async  fn run(
     sequencer_receiver_channel: CBReceiver<Transaction>,
     rollupdb_sender: CBSender<RollupDBMessage>,
+    account_receiver : Receiver<Option<Vec<(Pubkey,AccountSharedData)>>>,
 ) -> Result<()> {
     let mut tx_counter = 0u32;
 
+    let batch_size = 2;//adjust based on the requirements
+    let mut transaction_batch : Vec<Transaction> = Vec::with_capacity(batch_size);
     let rpc_client_temp = RpcClient::new("https://api.devnet.solana.com".to_string());
-
+    
     println!("Sequencer is running...");
-    let rollup_account_loader = RollupAccountLoader::new(&rpc_client_temp);
+    let mut rollup_account_loader = RollupAccountLoader::new(&rpc_client_temp);
 
-    while let transaction = sequencer_receiver_channel.recv().unwrap() {
-        let accounts_to_lock = transaction.message.account_keys.clone();
-        tx_counter += 1;
+    while let Ok(transaction) = sequencer_receiver_channel.recv() {
+        println!("{}",transaction_batch.len());
+        transaction_batch.push(transaction);
 
-        println!("send lock accounts to rollupdb");
-        // lock accounts in rollupdb to keep paralell execution possible, just like on solana
-        rollupdb_sender
-            .send(RollupDBMessage {
+        if transaction_batch.len() >= batch_size {
+            println!("processing a batch of {} transaction", transaction_batch.len());
+
+            let accounts_to_lock: Vec<Pubkey> = transaction_batch
+                .iter()
+                .flat_map(|tx| tx.message.account_keys.clone())
+                .collect::<HashSet<_>>() 
+                .into_iter()
+                .collect();
+
+            rollupdb_sender.send(RollupDBMessage {
                 lock_accounts: Some(accounts_to_lock),
+                add_processed_transaction: None,
+                add_new_data: None,
                 frontend_get_tx: None,
                 add_settle_proof: None,
-                add_processed_transaction: Some(transaction.clone()),
-            })
-            .map_err(|_| anyhow!("failed to send message to rollupdb"))?;
+            })?;
+            
+            if let Some(Some(accounts_data)) = account_receiver.recv().await.ok(){
+                for (pubkey, account) in accounts_data {
+                    rollup_account_loader.add_account(pubkey, account);
+                }
 
-        // Verify ransaction signatures, integrity
+                // the cache is pre-loaded and  process the entire batch
+                if let Err(e) = process_transaction_batch(
+                    &transaction_batch,
+                    &rollup_account_loader,
+                    &rollupdb_sender,
+                ) {
+                    log::error!("Error processing transaction batch: {}", e);
+                }
+            }else{
+                log::error!("Sequencer: Failed to receive account data from DB. Skipping batch.");
+            }
 
-        // Process transaction
+            tx_counter += transaction_batch.len() as u32;
+            transaction_batch.clear();
+            log::info!("Batch processing finished. Ready for new transactions.");
+        }
 
-        let compute_budget = SVMTransactionExecutionBudget::default();
-        let feature_set = SVMFeatureSet::all_enabled();
-        let fee_structure = FeeStructure::default();
-        let rent_collector = RentCollector::default();
-        // let rent_collector = RentCollector::default();
+            // // TODO Lock db to avoid state changes during settlement
 
-        // Solana runtime.
-        let fork_graph = Arc::new(RwLock::new(RollupForkGraph {}));
-
-        println!("Create batch transactions...");
-        // // create transaction processor, add accounts and programs, builtins,
-        let processor = create_transaction_batch_processor(
-            &rollup_account_loader,
-            &feature_set,
-            &compute_budget,
-            Arc::clone(&fork_graph),
-        );
-
-        let processing_environment = TransactionProcessingEnvironment {
-            blockhash: Hash::default(),
-            blockhash_lamports_per_signature: fee_structure.lamports_per_signature,
-            epoch_total_stake: 0,
-            feature_set,
-            rent_collector: Some(&rent_collector),
-        };
-
-        let processing_config = TransactionProcessingConfig::default();
-
-        let sanitized = SanitizedTransaction::try_from_legacy_transaction(
-            Transaction::from(transaction.clone()),
-            &HashSet::new(),
-        );
-
-        let sanitized_txs = &[sanitized.unwrap()];
-
-        println!("load and execute...");
-        let results = processor.load_and_execute_sanitized_transactions(
-            &rollup_account_loader,
-            sanitized_txs,
-            get_transaction_check_results(1),
-            &processing_environment,
-            &processing_config,
-        );
-
-        // let mut cache = processor.program_cache.write().unwrap();
-
-        // // Initialize the mocked fork graph.
-        // // let fork_graph = Arc::new(RwLock::new(PayTubeForkGraph {}));
-        // cache.fork_graph = Some(Arc::downgrade(&fork_graph));
-
-        // let rent = Rent::default();
-
-        // let default_env = EnvironmentConfig::new(blockhash, epoch_total_stake, epoch_vote_accounts, feature_set, lamports_per_signature, sysvar_cache)
-
-        // let processing_environment = TransactionProcessingEnvironment {
-        //     blockhash: Hash::default(),
-        //     epoch_total_stake: None,
-        //     epoch_vote_accounts: None,
-        //     feature_set: Arc::new(feature_set),
-        //     fee_structure: Some(&fee_structure),
-        //     lamports_per_signature,
-        //     rent_collector: Some(&rent_collector),
-        // };
-
-        // Send processed transaction to db for storage and availability
-        // println!("send transaction to rollupddb");
-        // rollupdb_sender
-        //     .send(RollupDBMessage {
-        //         lock_accounts: None,
-        //         add_processed_transaction: Some(transaction),
-        //         frontend_get_tx: None,
-        //         add_settle_proof: None,
-        //     })
-        //     .unwrap();
-
-        // Call settle if transaction amount since last settle hits 10
-        if tx_counter >= 2 {
-            // TODO Lock db to avoid state changes during settlement
-
-            // TODO Prepare root hash, or your own proof to send to chain
-
-            // Send proof to chain
-            println!("SETTLE to L1...");
+            // // TODO Prepare root hash, or your own proof to send to chain
+        if tx_counter >= 2 { // You might want to adjust this trigger
+            log::info!("SETTLE to L1...");
             let message = b"my rollup state proof or commitment";
             let message_hash = hash(message);
 
-            // ✅ Spawn an async task
             tokio::spawn(async move {
                 match settle_state(message_hash.into()).await {
                     Ok(hash) => log::info!("Settle hash: {}", hash),
                     Err(e) => log::error!("Settle failed: {:?}", e),
                 }
             });
-            tx_counter = 0u32;
+            tx_counter = 0;
         }
     }
-
     Ok(())
-}
-
-pub struct RollupAccountLoader<'a> {
-    cache: RwLock<HashMap<Pubkey, AccountSharedData>>,
-    rpc_client: &'a RpcClient,
-}
-
-impl<'a> RollupAccountLoader<'a> {
-    pub fn new(rpc_client: &'a RpcClient) -> Self {
-        Self {
-            cache: RwLock::new(HashMap::new()),
-            rpc_client,
-        }
-    }
-}
-
-impl InvokeContextCallback for RollupAccountLoader<'_> {
-    fn get_epoch_stake(&self) -> u64 {
-        0
-    }
-
-    fn get_epoch_stake_for_vote_account(&self, _vote_address: &Pubkey) -> u64 {
-        0
-    }
-
-    fn is_precompile(&self, _program_id: &Pubkey) -> bool {
-        false
-    }
-
-    fn process_precompile(
-        &self,
-        _program_id: &Pubkey,
-        _data: &[u8],
-        _instruction_datas: Vec<&[u8]>,
-    ) -> std::result::Result<(), solana_sdk::precompiles::PrecompileError> {
-        Err(solana_sdk::precompiles::PrecompileError::InvalidPublicKey)
-    }
-}
-
-// / Implementation of the SVM API's `TransactionProcessingCallback` interface.
-// /
-// / The SVM API requires this plugin be provided to provide the SVM with the
-// / ability to load accounts.
-// /
-// / In the Agave validator, this implementation is Bank, powered by AccountsDB.
-impl TransactionProcessingCallback for RollupAccountLoader<'_> {
-    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
-        if let Some(account) = self.cache.read().unwrap().get(pubkey) {
-            return Some(account.clone());
-        }
-
-        let account: AccountSharedData = self.rpc_client.get_account(pubkey).ok()?.into();
-        self.cache.write().unwrap().insert(*pubkey, account.clone());
-
-        Some(account)
-    }
-
-    fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize> {
-        self.get_account_shared_data(account)
-            .and_then(|account| owners.iter().position(|key| account.owner().eq(key)))
-    }
-
-    fn add_builtin_account(&self, _name: &str, _program_id: &Pubkey) {}
-
-    fn inspect_account(
-        &self,
-        _address: &Pubkey,
-        _account_state: solana_svm_callback::AccountState,
-        _is_writable: bool,
-    ) {
-    }
-
-    fn get_current_epoch_vote_account_stake(&self, _vote_address: &Pubkey) -> u64 {
-        // Stub implementation: return 0 or implement as needed
-        0
-    }
 }

--- a/rollup_core/src/settle.rs
+++ b/rollup_core/src/settle.rs
@@ -23,7 +23,7 @@ pub async fn settle_state(proof: Hash) -> Result<String> {
     // let payer = signer::keypair::read_keypair_file("/home/dev/.solana/testkey.json")
     //     .map_err(|e| anyhow::anyhow!("Failed to read keypair file: {}", e))?;
 
-    let payer = signer::keypair::read_keypair_file("/home/jvan/svm/zksvm/rollup_core/src/settler-keypair.json")
+    let payer = signer::keypair::read_keypair_file("/home/dev/.solana/testkey.json")
         .map_err(|e| anyhow::anyhow!("Failed to read keypair file: {}", e))?;
 
     // Create a dummy system transfer instruction (transfers 0 lamports to self)

--- a/rollup_core/src/settle.rs
+++ b/rollup_core/src/settle.rs
@@ -5,7 +5,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
-    signature::Signer,
+    signature::{Keypair, Signer},
     signer,
     system_program,
     transaction::Transaction,
@@ -20,7 +20,10 @@ pub async fn settle_state(proof: Hash) -> Result<String> {
     );
 
     // Load keypair from the specified path
-    let payer = signer::keypair::read_keypair_file("/home/dev/.solana/testkey.json")
+    // let payer = signer::keypair::read_keypair_file("/home/dev/.solana/testkey.json")
+    //     .map_err(|e| anyhow::anyhow!("Failed to read keypair file: {}", e))?;
+
+    let payer = signer::keypair::read_keypair_file("/home/jvan/svm/zksvm/rollup_core/src/settler-keypair.json")
         .map_err(|e| anyhow::anyhow!("Failed to read keypair file: {}", e))?;
 
     // Create a dummy system transfer instruction (transfers 0 lamports to self)


### PR DESCRIPTION
fixes #8 

- sequencer no longer processes transactions one by one. Instead, it collects incoming transactions into a "batch" until it reaches a set size 
- With a fully pre-loaded cache, the sequencer hands the entire batch of transactions to the SVM. The SVM can now execute all transactions at high speed because it never has to wait for data; every account it needs is already available in the local cache

yet to be done

1. generating & storing the proofs 
2. if a transaction fails, we can rerun the transaction(just an enhancement [Not really required at this point]) 
