### PR TITLE
add:  error handling for `get_transaction`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-KEYPAIR1 = "path_to_the_keypair_file"
-KEYPAIR2 = "path_to_the_keypair_file"
+KEYPAIR1 = "/home/dev/.solana/testkey.json"
+KEYPAIR2 = "/home/dev/.solana/mykey_1.json"

--- a/rollup_client/src/lib.rs
+++ b/rollup_client/src/lib.rs
@@ -33,7 +33,8 @@ pub async fn submit_transaction_to_rollup(
 ) -> Result<HashMap<String, String>> {
     let rollup_tx = RollupTransaction {
         sender: sender_name.to_string(),
-        sol_transaction: transaction,
+        sol_transaction: Some(transaction),
+        error: None
     };
 
     let response = client

--- a/rollup_core/src/frontend.rs
+++ b/rollup_core/src/frontend.rs
@@ -4,20 +4,20 @@ use std::{
 };
 
 use actix_web::{error, web, HttpResponse};
-use async_channel::{Receiver, Send, Sender};
+use async_channel::Receiver;
 use crossbeam::channel::{Receiver as CBReceiver, Sender as CBSender};
 use serde::{Deserialize, Serialize};
-use solana_sdk::keccak::{hashv, Hash};
+use solana_sdk::keccak::Hash;
 use solana_sdk::transaction::Transaction;
 use std::str::FromStr;
 
 use crate::rollupdb::RollupDBMessage;
 
 // message format to send found transaction from db to frontend
-
 pub struct FrontendMessage {
     pub get_tx: Option<Hash>,
     pub transaction: Option<Transaction>,
+    pub error: Option<String>,
 }
 
 // message format used to get transaction client
@@ -26,27 +26,28 @@ pub struct GetTransaction {
     pub get_tx: String,
 }
 
-// message format used to receive transactions from clients
+// unified message format for frontend <-> backend
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RollupTransaction {
     pub sender: String,
-    pub sol_transaction: Transaction,
+    pub sol_transaction: Option<Transaction>,
+    pub error: Option<String>,
 }
 
 pub async fn submit_transaction(
     body: web::Json<RollupTransaction>,
     sequencer_sender: web::Data<CBSender<Transaction>>,
-    // rollupdb_sender: web::Data<Sender<RollupDBMessage>>,
 ) -> actix_web::Result<HttpResponse> {
-    // Validate transaction structure with serialization in function signature
     log::info!("Submitted transaction");
     log::info!("{body:?}");
 
-    // Send transaction to sequencer
-    sequencer_sender.send(body.sol_transaction.clone()).unwrap();
-
-    // Return response
-    Ok(HttpResponse::Ok().json(HashMap::from([("Transaction status", "Submitted")])))
+    if let Some(tx) = body.sol_transaction.clone() {
+        sequencer_sender.send(tx).unwrap();
+        Ok(HttpResponse::Ok().json(HashMap::from([("Transaction status", "Submitted")])))
+    } else {
+        log::warn!("Submit request missing sol_transaction");
+        Ok(HttpResponse::BadRequest().json(HashMap::from([("error", "Missing sol_transaction")])))
+    }
 }
 
 pub async fn get_transaction(
@@ -54,34 +55,35 @@ pub async fn get_transaction(
     rollupdb_sender: web::Data<CBSender<RollupDBMessage>>,
     frontend_receiver: web::Data<Receiver<FrontendMessage>>,
 ) -> actix_web::Result<HttpResponse> {
-    // Validate transaction structure with serialization in function signature
-    log::info!("Requested transaction");
-    log::info!("{body:?}");
-    log::info!("ADD ROLLUPDB tx");
+    log::info!("Requested transaction: {:?}", body);
     let sig = body.get_tx.clone();
-    log::info!("FRONTEND TX: {}", sig);
-  
 
     rollupdb_sender
         .send(RollupDBMessage {
             lock_accounts: None,
             add_processed_transaction: None,
             frontend_get_tx: Some(
-                Hash::from_str(&body.get_tx).map_err(|_| error::ErrorBadRequest("Invalid hash"))?,
+                Hash::from_str(&sig).map_err(|_| error::ErrorBadRequest("Invalid hash"))?,
             ),
             add_settle_proof: None,
-            add_new_data:None
+            add_new_data: None,
         })
         .unwrap();
-    log::info!("Sending to rollupdb worked getrequest");
 
     if let Ok(frontend_message) = frontend_receiver.recv().await {
-        log::info!("Rollup db got getrequest");
-        return Ok(HttpResponse::Ok().json(RollupTransaction {
-            sender: "Rollup RPC".into(),
-            sol_transaction: frontend_message.transaction.unwrap(),
-        }));
-        // Ok(HttpResponse::Ok().json(HashMap::from([("Transaction status", "requested")])))
+        if let Some(tx) = frontend_message.transaction {
+            return Ok(HttpResponse::Ok().json(RollupTransaction {
+                sender: "Rollup RPC".into(),
+                sol_transaction: Some(tx),
+                error: None,
+            }));
+        } else if let Some(err) = frontend_message.error {
+            return Ok(HttpResponse::Ok().json(RollupTransaction {
+                sender: "Rollup RPC".into(),
+                sol_transaction: None,
+                error: Some(err),
+            }));
+        }
     }
 
     Ok(HttpResponse::Ok().json(HashMap::from([("Transaction status", "requested")])))


### PR DESCRIPTION
Since we don't store single transactions on the RollupDB anymore,  the get_transaction has gotten some issues
- Transactions get only pushed if batches hit limit
- No immediate GET for transactions on the rollup_client

Therefor first some error handling